### PR TITLE
Fix issue in JobMaintainer with overlapping names

### DIFF
--- a/app/jobs/cron/prefixed_my_repeated_job.rb
+++ b/app/jobs/cron/prefixed_my_repeated_job.rb
@@ -1,0 +1,11 @@
+require_relative '../application_job.rb'
+
+class PrefixedMyRepeatedJob < ApplicationJob
+  queue_as :low_priority
+
+  def self.cron
+    '0 11 * * *'
+  end
+
+  def perform; end
+end

--- a/lib/delayed/job_maintainer.rb
+++ b/lib/delayed/job_maintainer.rb
@@ -6,7 +6,7 @@ class Delayed::JobMaintainer
     delete_jobs_with_no_job_class
     job_classes.each do |klass|
       next if klass.cron.blank?
-      if (existing = cron_jobs.where("handler LIKE ?", "%#{klass}%").first)
+      if (existing = cron_jobs.where("handler LIKE ?", "%job_class: #{klass}%").first)
         update_existing(existing, klass)
       else # create new
         klass.perform_later

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,7 @@ require 'delayed_cron_job'
 require 'delayed_cron_job_extras'
 
 require_relative '../app/jobs/cron/my_repeated_job.rb'
+require_relative '../app/jobs/cron/prefixed_my_repeated_job.rb'
 
 Delayed::Worker.logger = Logger.new("/tmp/dj.log")
 ENV["RAILS_ENV"] = "test"


### PR DESCRIPTION
Fixes a bug where the job maintainer would only enqueue one these jobs

PrefixedMyRepeatedJob
MyRepeatedJob